### PR TITLE
0.6.7 — 1.21.11 Port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.15-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -21,7 +21,7 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	mappings loom.officialMojangMappings()
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
@@ -60,7 +60,7 @@ jar {
 // configure the maven publication
 publishing {
 	publications {
-		mavenJava(MavenPublication) {
+		create("mavenJava", MavenPublication) {
 			from components.java
 		}
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,13 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.11
+loader_version=0.18.4
 
 # Mod Properties
-mod_version=0.6.0
+mod_version=0.6.7
 maven_group=com.jamino.nimblerewynnded
 archives_base_name=NimbleReWynnded
 
 # Dependencies
-fabric_version=0.115.1+1.21.4
+fabric_version=0.141.3+1.21.11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/jamino/nimblerewynnded/NimbleRewynnded.java
+++ b/src/main/java/com/jamino/nimblerewynnded/NimbleRewynnded.java
@@ -3,158 +3,132 @@ package com.jamino.nimblerewynnded;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.minecraft.client.option.KeyBinding;
-import net.minecraft.client.option.Perspective;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.util.InputUtil;
-import net.minecraft.world.GameMode;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.vehicle.AbstractMinecartEntity;
-import net.minecraft.entity.passive.HorseEntity;
-import net.minecraft.entity.vehicle.BoatEntity;
-import net.minecraft.entity.passive.StriderEntity;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.CameraType;
+import net.minecraft.client.Minecraft;
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart;
+import net.minecraft.world.entity.animal.equine.Horse;
+import net.minecraft.world.entity.vehicle.boat.Boat;
+import net.minecraft.world.entity.monster.Strider;
 import org.lwjgl.glfw.GLFW;
 
 public class NimbleRewynnded implements ClientModInitializer {
-    private static NimbleRewynnded instance;
-    private static KeyBinding togglePerspectiveKey;
-    private static KeyBinding frontViewKey;
-    private Perspective lastPerspective = Perspective.FIRST_PERSON;
-    private Perspective preRidingPerspective = Perspective.FIRST_PERSON;
-    private boolean wasInSpectator = false;
-    private boolean wasRiding = false;
+    private KeyMapping togglePerspectiveKey;
+    private KeyMapping frontViewKey;
+    private CameraType lastPerspective = CameraType.FIRST_PERSON;
+    private CameraType preRidingPerspective = CameraType.FIRST_PERSON;
+    private boolean wasInSpectator;
+    private boolean wasRiding;
+    private CameraType perspectiveBeforeTick = CameraType.FIRST_PERSON;
 
     @Override
     public void onInitializeClient() {
-        instance = this;
-        togglePerspectiveKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+        KeyMapping.Category category = KeyMapping.Category.register(Identifier.parse("nimblerewynnded:keys"));
+        togglePerspectiveKey = new KeyMapping(
                 "key.nimblerewynnded.toggleperspective",
-                InputUtil.Type.KEYSYM,
+                InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_F5,
-                "category.nimblerewynnded.general"
-        ));
+                KeyMapping.Category.MISC
+        );
 
-        frontViewKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+        frontViewKey = KeyBindingHelper.registerKeyBinding(new KeyMapping(
                 "key.nimblerewynnded.frontview",
-                InputUtil.Type.KEYSYM,
+                InputConstants.Type.KEYSYM,
                 GLFW.GLFW_KEY_LEFT_ALT,
-                "category.nimblerewynnded.general"
+                category
         ));
 
+        ClientTickEvents.START_CLIENT_TICK.register(client -> {
+            if (client.player != null) {
+                perspectiveBeforeTick = client.options.getCameraType();
+            }
+        });
         ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
     }
 
-    public static NimbleRewynnded getInstance() {
-        return instance;
-    }
+    private void onClientTick(Minecraft client) {
+        if (client.player == null || client.gameMode == null) return;
 
-    private void onClientTick(MinecraftClient client) {
-        if (client.player == null || client.interactionManager == null) return;
-
-        handlePerspectiveToggle(client);
+        handlePerspectiveToggle(client, perspectiveBeforeTick);
         handleFrontViewToggle(client);
         handleCutscenePerspective(client);
         handleRidingPerspective(client);
     }
 
-    private void handlePerspectiveToggle(MinecraftClient client) {
-        if (togglePerspectiveKey.wasPressed()) {
-            Perspective currentPerspective = client.options.getPerspective();
-            if (currentPerspective == Perspective.FIRST_PERSON) {
-                client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
+    private void handlePerspectiveToggle(Minecraft client, CameraType perspectiveBeforeTick) {
+        if (client.player == null) return;
+        if (togglePerspectiveKey.consumeClick()) {
+            if (perspectiveBeforeTick == CameraType.FIRST_PERSON) {
+                client.options.setCameraType(CameraType.THIRD_PERSON_BACK);
             } else {
-                client.options.setPerspective(Perspective.FIRST_PERSON);
+                client.options.setCameraType(CameraType.FIRST_PERSON);
             }
-            lastPerspective = client.options.getPerspective();
-            if (client.player.hasVehicle()) {
+            lastPerspective = client.options.getCameraType();
+            if (client.player.isPassenger()) {
                 preRidingPerspective = lastPerspective;
             }
         }
     }
 
-    private void handleFrontViewToggle(MinecraftClient client) {
-        if (frontViewKey.isPressed()) {
-            if (client.options.getPerspective() != Perspective.THIRD_PERSON_FRONT) {
-                lastPerspective = client.options.getPerspective();
-                client.options.setPerspective(Perspective.THIRD_PERSON_FRONT);
+    private void handleFrontViewToggle(Minecraft client) {
+        if (frontViewKey.isDown()) {
+            if (client.options.getCameraType() != CameraType.THIRD_PERSON_FRONT) {
+                lastPerspective = client.options.getCameraType();
+                client.options.setCameraType(CameraType.THIRD_PERSON_FRONT);
             }
-        } else if (client.options.getPerspective() == Perspective.THIRD_PERSON_FRONT) {
-            client.options.setPerspective(lastPerspective);
+        } else if (client.options.getCameraType() == CameraType.THIRD_PERSON_FRONT) {
+            client.options.setCameraType(lastPerspective);
         }
     }
 
-    private void handleCutscenePerspective(MinecraftClient client) {
-        boolean isInSpectator = client.interactionManager.getCurrentGameMode() == GameMode.SPECTATOR;
+    private void handleCutscenePerspective(Minecraft client) {
+        if (client.gameMode == null) return;
+        boolean isInSpectator = client.gameMode.getPlayerMode() == GameType.SPECTATOR;
 
         // Wynncraft-specific cutscene handling
         // This method detects when the player enters spectator mode, which is used for cutscenes in Wynncraft
         if (isInSpectator && !wasInSpectator) {
-            lastPerspective = client.options.getPerspective();
-            client.options.setPerspective(Perspective.FIRST_PERSON);
+            lastPerspective = client.options.getCameraType();
+            client.options.setCameraType(CameraType.FIRST_PERSON);
         } else if (!isInSpectator && wasInSpectator) {
-            client.options.setPerspective(lastPerspective);
+            client.options.setCameraType(lastPerspective);
         }
 
         wasInSpectator = isInSpectator;
     }
 
-    private void handleRidingPerspective(MinecraftClient client) {
-        boolean isRiding = client.player.hasVehicle();
+    private void handleRidingPerspective(Minecraft client) {
+        if (client.player == null) return;
+        boolean isRiding = client.player.isPassenger();
 
         if (isRiding != wasRiding) {
             if (isRiding) {
                 Entity vehicle = client.player.getVehicle();
                 if (!wasInSpectator && shouldChangePerspective(vehicle)) {
-                    if (client.options.getPerspective() == Perspective.FIRST_PERSON ||
-                            client.options.getPerspective() == Perspective.THIRD_PERSON_FRONT) {
-                        preRidingPerspective = client.options.getPerspective();
-                        client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
-                    } else {
-                        preRidingPerspective = client.options.getPerspective();
+                    preRidingPerspective = client.options.getCameraType();
+                    if (preRidingPerspective == CameraType.FIRST_PERSON ||
+                            preRidingPerspective == CameraType.THIRD_PERSON_FRONT) {
+                        client.options.setCameraType(CameraType.THIRD_PERSON_BACK);
                     }
                 }
             } else {
                 if (!wasInSpectator) {
-                    client.options.setPerspective(preRidingPerspective);
+                    client.options.setCameraType(preRidingPerspective);
                 }
             }
             wasRiding = isRiding;
         }
     }
+
     //Add new entity classes here if wynncraft adds custom mounts
     private boolean shouldChangePerspective(Entity vehicle) {
-        return vehicle instanceof AbstractMinecartEntity
-                || vehicle instanceof HorseEntity
-                || vehicle instanceof BoatEntity
-                || vehicle instanceof StriderEntity
-                || vehicle.getClass().getSimpleName().equals("class_1506");
-    }
-
-    public void mountEvent(Entity entity, boolean mount) {
-        MinecraftClient client = MinecraftClient.getInstance();
-
-        if (entity != client.player) {
-            return;
-        }
-
-        Entity vehicle = client.player.getVehicle();
-
-        if (mount) {
-            if (vehicle != null && shouldChangePerspective(vehicle)) {
-                if (client.options.getPerspective() == Perspective.FIRST_PERSON ||
-                        client.options.getPerspective() == Perspective.THIRD_PERSON_FRONT) {
-                    preRidingPerspective = client.options.getPerspective();
-                    client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
-                } else {
-                    preRidingPerspective = client.options.getPerspective();
-                }
-                wasRiding = true;
-            }
-        } else {
-            if (wasRiding) {
-                client.options.setPerspective(preRidingPerspective);
-                wasRiding = false;
-            }
-        }
+        return vehicle instanceof AbstractMinecart
+                || vehicle instanceof Horse
+                || vehicle instanceof Boat
+                || vehicle instanceof Strider;
     }
 }

--- a/src/main/resources/assets/nimblerewynnded/lang/cs_cz.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/cs_cz.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Hbitý Přetočený", "key.nimblerewynnded.toggleperspective": "Přepnout pohled třetí osoby", "key.nimblerewynnded.frontview": "Podržte pro čelní pohled"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Přepnout pohled třetí osoby", "key.nimblerewynnded.frontview": "Podržte pro čelní pohled"}

--- a/src/main/resources/assets/nimblerewynnded/lang/de_de.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/de_de.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Flink Neugewunden", "key.nimblerewynnded.toggleperspective": "Dritte-Person-Ansicht umschalten", "key.nimblerewynnded.frontview": "Halten für Frontansicht"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Dritte-Person-Ansicht umschalten", "key.nimblerewynnded.frontview": "Halten für Frontansicht"}

--- a/src/main/resources/assets/nimblerewynnded/lang/el_gr.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/el_gr.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Ευέλικτο Ξανατυλιγμένο", "key.nimblerewynnded.toggleperspective": "Εναλλαγή προβολής τρίτου προσώπου", "key.nimblerewynnded.frontview": "Κρατήστε πατημένο για μπροστινή προβολή"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Εναλλαγή προβολής τρίτου προσώπου", "key.nimblerewynnded.frontview": "Κρατήστε πατημένο για μπροστινή προβολή"}

--- a/src/main/resources/assets/nimblerewynnded/lang/en_us.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "category.nimblerewynnded.general": "Nimble ReWynnded",
+  "key.category.nimblerewynnded.keys": "Nimble ReWynnded",
   "key.nimblerewynnded.toggleperspective": "Toggle Third Person",
   "key.nimblerewynnded.frontview": "Hold for Front View"
 }

--- a/src/main/resources/assets/nimblerewynnded/lang/es_es.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/es_es.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Ágil Rebobinado", "key.nimblerewynnded.toggleperspective": "Alternar tercera persona", "key.nimblerewynnded.frontview": "Mantener para vista frontal"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Alternar tercera persona", "key.nimblerewynnded.frontview": "Mantener para vista frontal"}

--- a/src/main/resources/assets/nimblerewynnded/lang/fi_fi.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/fi_fi.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Ketterä Uudelleenkelattu", "key.nimblerewynnded.toggleperspective": "Vaihda kolmannen persoonan näkymää", "key.nimblerewynnded.frontview": "Pidä pohjassa etunäkymää varten"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Vaihda kolmannen persoonan näkymää", "key.nimblerewynnded.frontview": "Pidä pohjassa etunäkymää varten"}

--- a/src/main/resources/assets/nimblerewynnded/lang/fr_fr.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/fr_fr.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Nimble Rebobiné", "key.nimblerewynnded.toggleperspective": "Basculer en vue à la troisième personne", "key.nimblerewynnded.frontview": "Maintenir pour la vue de face"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Basculer en vue à la troisième personne", "key.nimblerewynnded.frontview": "Maintenir pour la vue de face"}

--- a/src/main/resources/assets/nimblerewynnded/lang/hu_hu.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/hu_hu.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Fürge Visszatekert", "key.nimblerewynnded.toggleperspective": "Harmadik személyű nézet váltása", "key.nimblerewynnded.frontview": "Tartsd lenyomva az elölnézethez"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Harmadik személyű nézet váltása", "key.nimblerewynnded.frontview": "Tartsd lenyomva az elölnézethez"}

--- a/src/main/resources/assets/nimblerewynnded/lang/it_it.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/it_it.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Agile Riavvolto", "key.nimblerewynnded.toggleperspective": "Attiva/disattiva terza persona", "key.nimblerewynnded.frontview": "Tieni premuto per vista frontale"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Attiva/disattiva terza persona", "key.nimblerewynnded.frontview": "Tieni premuto per vista frontale"}

--- a/src/main/resources/assets/nimblerewynnded/lang/ja_jp.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/ja_jp.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "ニンブル・リワインド", "key.nimblerewynnded.toggleperspective": "三人称視点の切り替え", "key.nimblerewynnded.frontview": "正面ビューを表示"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "三人称視点の切り替え", "key.nimblerewynnded.frontview": "正面ビューを表示"}

--- a/src/main/resources/assets/nimblerewynnded/lang/ko_kr.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/ko_kr.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "님블 리와인드", "key.nimblerewynnded.toggleperspective": "3인칭 시점 전환", "key.nimblerewynnded.frontview": "정면 뷰 유지"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "3인칭 시점 전환", "key.nimblerewynnded.frontview": "정면 뷰 유지"}

--- a/src/main/resources/assets/nimblerewynnded/lang/nl_nl.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/nl_nl.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Vlug Teruggespoeld", "key.nimblerewynnded.toggleperspective": "Schakel derdepersoons-weergave", "key.nimblerewynnded.frontview": "Houd ingedrukt voor vooraanzicht"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Schakel derdepersoons-weergave", "key.nimblerewynnded.frontview": "Houd ingedrukt voor vooraanzicht"}

--- a/src/main/resources/assets/nimblerewynnded/lang/pl_pl.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/pl_pl.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Zwinny Przewinięty", "key.nimblerewynnded.toggleperspective": "Przełącz widok trzecioosobowy", "key.nimblerewynnded.frontview": "Przytrzymaj dla widoku z przodu"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Przełącz widok trzecioosobowy", "key.nimblerewynnded.frontview": "Przytrzymaj dla widoku z przodu"}

--- a/src/main/resources/assets/nimblerewynnded/lang/pt_br.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/pt_br.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Ágil Rebobinado", "key.nimblerewynnded.toggleperspective": "Alternar terceira pessoa", "key.nimblerewynnded.frontview": "Segurar para visão frontal"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Alternar terceira pessoa", "key.nimblerewynnded.frontview": "Segurar para visão frontal"}

--- a/src/main/resources/assets/nimblerewynnded/lang/ru_ru.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/ru_ru.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Проворный Перемотанный", "key.nimblerewynnded.toggleperspective": "Переключить вид от третьего лица", "key.nimblerewynnded.frontview": "Удерживать для вида спереди"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Переключить вид от третьего лица", "key.nimblerewynnded.frontview": "Удерживать для вида спереди"}

--- a/src/main/resources/assets/nimblerewynnded/lang/sv_se.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/sv_se.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Smidig Omspolad", "key.nimblerewynnded.toggleperspective": "Växla tredjepersonsperspektiv", "key.nimblerewynnded.frontview": "Håll för frontvy"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Växla tredjepersonsperspektiv", "key.nimblerewynnded.frontview": "Håll för frontvy"}

--- a/src/main/resources/assets/nimblerewynnded/lang/th_th.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/th_th.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "คล่องแคล่วย้อนกลับ", "key.nimblerewynnded.toggleperspective": "สลับมุมมองบุคคลที่สาม", "key.nimblerewynnded.frontview": "กดค้างสำหรับมุมมองด้านหน้า"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "สลับมุมมองบุคคลที่สาม", "key.nimblerewynnded.frontview": "กดค้างสำหรับมุมมองด้านหน้า"}

--- a/src/main/resources/assets/nimblerewynnded/lang/tr_tr.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/tr_tr.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Çevik Yeniden Sarılmış", "key.nimblerewynnded.toggleperspective": "Üçüncü Şahıs Görünümünü Değiştir", "key.nimblerewynnded.frontview": "Ön Görünüm için Basılı Tut"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Üçüncü Şahıs Görünümünü Değiştir", "key.nimblerewynnded.frontview": "Ön Görünüm için Basılı Tut"}

--- a/src/main/resources/assets/nimblerewynnded/lang/uk_ua.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/uk_ua.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Спритний Перемотаний", "key.nimblerewynnded.toggleperspective": "Перемкнути вид від третьої особи", "key.nimblerewynnded.frontview": "Утримуйте для виду спереду"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Перемкнути вид від третьої особи", "key.nimblerewynnded.frontview": "Утримуйте для виду спереду"}

--- a/src/main/resources/assets/nimblerewynnded/lang/vi_vn.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/vi_vn.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "Nhanh Nhẹn Tua Lại", "key.nimblerewynnded.toggleperspective": "Chuyển đổi góc nhìn người thứ ba", "key.nimblerewynnded.frontview": "Giữ để xem góc nhìn phía trước"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "Chuyển đổi góc nhìn người thứ ba", "key.nimblerewynnded.frontview": "Giữ để xem góc nhìn phía trước"}

--- a/src/main/resources/assets/nimblerewynnded/lang/zh_cn.json
+++ b/src/main/resources/assets/nimblerewynnded/lang/zh_cn.json
@@ -1,1 +1,1 @@
-{"category.nimblerewynnded.general": "灵动重生", "key.nimblerewynnded.toggleperspective": "切换第三人称视角", "key.nimblerewynnded.frontview": "按住显示正面视图"}
+{"key.category.nimblerewynnded.keys": "Nimble ReWynnded", "key.nimblerewynnded.toggleperspective": "切换第三人称视角", "key.nimblerewynnded.frontview": "按住显示正面视图"}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,9 +20,6 @@
 			"com.jamino.nimblerewynnded.NimbleRewynnded"
 		]
 	},
-	"mixins": [
-		"nimblerewynnded.mixins.json"
-	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
 		"minecraft": "~1.21",


### PR DESCRIPTION
Updated
- Ported to Minecraft 1.21.11
- Migrated from Yarn mappings to official Mojang mappings
- Updated Fabric Loader to 0.18.4
- Updated Fabric API to 0.141.3+1.21.11
- Updated Fabric Loom to 1.15-SNAPSHOT
- Updated Gradle wrapper to 9.4.0

Fixed
- Key category now displays as "Nimble ReWynnded" instead of a raw translation key in all languages
- Perspective toggle no longer conflicts with vanilla F5, perspective is captured before vanilla processes the key each tick
- Corrected entity class package paths for 1.21.11

Removed
- EntityMixin — riding detection is now handled entirely via tick events, no mixin needed

(Sorry, not really lol67)